### PR TITLE
Update lock palette functionality to fix bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,40 +7,40 @@
     <main>
       <h1>COLORANDOM</h1>
       <section class="color-box-container">
-        <article class="color-box" id="0">
-          <div class="color">
+        <article class="color-box">
+          <div class="color" id="0">
           </div>
           <div class="hex-and-lock">
             <p>HEX123</p>
             <img src="./src/unlock.png">
           </div>
         </article>
-        <article class="color-box" id="1">
-          <div class="color">
+        <article class="color-box">
+          <div class="color" id="1">
           </div>
           <div class="hex-and-lock">
             <p>HEX123</p>
             <img src="./src/unlock.png">
           </div>
         </article>
-        <article class="color-box" id="2">
-          <div class="color">
+        <article class="color-box">
+          <div class="color" id="2">
           </div>
           <div class="hex-and-lock">
             <p>HEX123</p>
             <img src="./src/unlock.png">
           </div>
         </article>
-        <article class="color-box" id="3">
-          <div class="color">
+        <article class="color-box">
+          <div class="color" id="3">
           </div>
           <div class="hex-and-lock">
             <p>HEX123</p>
             <img src="./src/unlock.png">
           </div>
         </article>
-        <article class="color-box" id="4">
-          <div class="color">
+        <article class="color-box">
+          <div class="color" id="4">
           </div>
           <div class="hex-and-lock">
             <p>HEX123</p>

--- a/scripts.js
+++ b/scripts.js
@@ -105,7 +105,7 @@ function displayNewColors() {
 
 function lockColor(event) {
   for (let i = 0; i < newPalette.colors.length; i++) {
-    if (event.target.closest(".color-box").id === newPalette.colors[i].divId) {
+    if (event.target.getAttribute('id') === newPalette.colors[i].divId) {
       newPalette.colors[i].locked = !newPalette.colors[i].locked;
       hexAndLock[i].innerHTML = "";
       hexAndLock[i].innerHTML +=


### PR DESCRIPTION
Hi Alex and Matt - 

I updated the lockColor function to work when just the color is clicked on (not the entire color box container).  Based on the instructions for iteration 4, it looks like only the color needs to be clicked on to lock the color, not the hex code or lock image. This got rid of the bug that was showing up when the hex code and lock were being clicked.  Let me know if you have any changes!

Thanks,
Nikki